### PR TITLE
AI 모델에 이미지 조작을 요청할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
 	runtimeOnly 'com.h2database:h2:2.2.224'
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	runtimeOnly 'com.h2database:h2:2.2.224'
 

--- a/src/main/java/org/rogarithm/presize/config/WebClientConfig.java
+++ b/src/main/java/org/rogarithm/presize/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package org.rogarithm.presize.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
@@ -1,0 +1,35 @@
+package org.rogarithm.presize.service;
+
+import org.rogarithm.presize.service.dto.ImgUploadDto;
+import org.rogarithm.presize.web.response.ImgUploadResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class ImgUploadService {
+
+    @Value("${ai.model.url}")
+    private String aiModelUrl;
+
+    @Autowired
+    private WebClient.Builder webClientBuilder;
+
+    public ImgUploadResponse uploadImg(ImgUploadDto dto) {
+        WebClient webClient = webClientBuilder.build();
+        WebClient.ResponseSpec retrieve = webClient.post()
+                .uri(aiModelUrl)
+                .bodyValue(dto)
+                .retrieve();
+        Mono<ImgUploadResponse> response = retrieve.bodyToMono(ImgUploadResponse.class);
+        ImgUploadResponse imgUploadResponse = response.block();
+
+        if (imgUploadResponse != null) {
+            return new ImgUploadResponse(imgUploadResponse.getResizedImgAsString());
+        }
+
+        throw new RuntimeException("Failed to retrieve a valid response from AI model");
+    }
+}

--- a/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
@@ -26,10 +26,14 @@ public class ImgUploadService {
         Mono<ImgUploadResponse> response = retrieve.bodyToMono(ImgUploadResponse.class);
         ImgUploadResponse imgUploadResponse = response.block();
 
-        if (imgUploadResponse != null) {
-            return new ImgUploadResponse(imgUploadResponse.getResizedImgAsString());
+        if (imgUploadResponse == null) {
+            throw new RuntimeException("Failed to retrieve a response from the AI model");
         }
 
-        throw new RuntimeException("Failed to retrieve a valid response from AI model");
+        if (imgUploadResponse.isSuccess()) {
+            return imgUploadResponse;
+        }
+
+        throw new RuntimeException("Error from AI model: " + imgUploadResponse.getMessage());
     }
 }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUploadDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUploadDto.java
@@ -12,7 +12,7 @@ public class ImgUploadDto {
 
     public ImgUploadDto(MultipartFile file, String height, String width) {
         try {
-            this.img = Base64.getEncoder().encodeToString(file.getBytes());
+            this.img = encodeWithPadding(Base64.getEncoder().encodeToString(file.getBytes()));
         } catch (Exception e) {
             throw new RuntimeException("Failed to encode image", e);
         }
@@ -34,5 +34,13 @@ public class ImgUploadDto {
 
     public int getWidth() {
         return width;
+    }
+
+    private String encodeWithPadding(String base64) {
+        int paddingLength = 4 - (base64.length() % 4);
+        if (paddingLength < 4) {
+            return base64 + "=".repeat(paddingLength);
+        }
+        return base64;
     }
 }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUploadDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUploadDto.java
@@ -1,0 +1,38 @@
+package org.rogarithm.presize.service.dto;
+
+import org.rogarithm.presize.web.request.ImgUploadRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Base64;
+
+public class ImgUploadDto {
+    private String img;
+    private int height;
+    private int width;
+
+    public ImgUploadDto(MultipartFile file, String height, String width) {
+        try {
+            this.img = Base64.getEncoder().encodeToString(file.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to encode image", e);
+        }
+        this.height = Integer.parseInt(height);
+        this.width = Integer.parseInt(width);
+    }
+
+    public static ImgUploadDto from(ImgUploadRequest request) {
+        return new ImgUploadDto(request.getFile(), request.getHeight(), request.getWidth());
+    }
+
+    public String getImg() {
+        return img;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 
 @Controller
-@RequestMapping("/spring")
+@RequestMapping
 public class ImgUploadController {
     private static final Logger log = LoggerFactory.getLogger(ImgUploadController.class);
 
@@ -23,15 +23,16 @@ public class ImgUploadController {
     private String fileDir;
 
     @GetMapping("/upload")
-    public String newFile() {
-        return "/upload-form";
+    public String newFile(Model model, ImgUploadRequest request) {
+        model.addAttribute("ImgUploadRequest", request);
+        return "/upload-img";
     }
 
-    @PostMapping("/upload")
-    public String saveFile(@RequestParam String itemName,
-                           @RequestParam MultipartFile file, HttpServletRequest request) throws IOException {
-        log.info("request={}", request);
-        log.info("itemName={}", itemName);
+    @PostMapping("/upload-file")
+    public String saveFile(@RequestBody ImgUploadRequest request) throws IOException {
+
+        service.uploadImg(ImgUploadDto.from(request));
+        MultipartFile file = request.getFile();
         log.info("multipartFile={}", file);
 
         if (!file.isEmpty()) {

--- a/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
@@ -1,14 +1,15 @@
 package org.rogarithm.presize.web;
 
-import jakarta.servlet.http.HttpServletRequest;
+import org.rogarithm.presize.service.ImgUploadService;
+import org.rogarithm.presize.service.dto.ImgUploadDto;
+import org.rogarithm.presize.web.request.ImgUploadRequest;
+import org.rogarithm.presize.web.response.ImgUploadResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -21,6 +22,12 @@ public class ImgUploadController {
 
     @Value("${file.dir}")
     private String fileDir;
+
+    private final ImgUploadService service;
+
+    public ImgUploadController(ImgUploadService service) {
+        this.service = service;
+    }
 
     @GetMapping("/upload")
     public String newFile(Model model, ImgUploadRequest request) {
@@ -42,5 +49,12 @@ public class ImgUploadController {
         }
 
         return "/upload-form";
+    }
+
+    @PostMapping("/upload")
+    public ImgUploadResponse uploadImg(@ModelAttribute("ImgUploadRequest") ImgUploadRequest request) throws IOException {
+        ImgUploadDto from = new ImgUploadDto(request.getFile(), "1240", "1240");
+        ImgUploadResponse response = service.uploadImg(from);
+        return response;
     }
 }

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUploadRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUploadRequest.java
@@ -1,0 +1,42 @@
+package org.rogarithm.presize.web.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImgUploadRequest {
+    private MultipartFile file;
+    private String height;
+    private String width;
+
+    public ImgUploadRequest() {
+    }
+
+    public ImgUploadRequest(MultipartFile file, String height, String width) {
+        this.file = file;
+        this.height = height;
+        this.width = width;
+    }
+
+    public MultipartFile getFile() {
+        return file;
+    }
+
+    public String getHeight() {
+        return height;
+    }
+
+    public String getWidth() {
+        return width;
+    }
+
+    public void setFile(MultipartFile file) {
+        this.file = file;
+    }
+
+    public void setHeight(String height) {
+        this.height = height;
+    }
+
+    public void setWidth(String width) {
+        this.width = width;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/web/response/ImgUploadResponse.java
+++ b/src/main/java/org/rogarithm/presize/web/response/ImgUploadResponse.java
@@ -1,0 +1,27 @@
+package org.rogarithm.presize.web.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class ImgUploadResponse {
+    @JsonProperty("resized_img")
+    private String resizedImg;
+
+    public ImgUploadResponse(@JsonProperty("resized_img") String resizedImg) {
+        this.resizedImg = resizedImg;
+    }
+
+    public String getResizedImg() {
+        return resizedImg;
+    }
+
+    public String getResizedImgAsString() {
+        if (resizedImg != null) {
+            byte[] decodedBytes = Base64.getDecoder().decode(resizedImg);
+            return new String(decodedBytes, StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/web/response/ImgUploadResponse.java
+++ b/src/main/java/org/rogarithm/presize/web/response/ImgUploadResponse.java
@@ -6,15 +6,31 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class ImgUploadResponse {
+    private final int code;
     @JsonProperty("resized_img")
-    private String resizedImg;
+    private final String resizedImg;
+    private final String message;
 
-    public ImgUploadResponse(@JsonProperty("resized_img") String resizedImg) {
+    public ImgUploadResponse(int code, @JsonProperty("resized_img") String resizedImg, String message) {
+        this.code = code;
         this.resizedImg = resizedImg;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
     }
 
     public String getResizedImg() {
         return resizedImg;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isSuccess() {
+        return code == 200 && resizedImg != null;
     }
 
     public String getResizedImgAsString() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: presize
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 25MB
   datasource:
     url: jdbc:h2:mem:test #localhost:port/h2-console? ?? ?? ? jdbc url ???
     driver-class-name: org.h2.Driver
@@ -11,3 +15,6 @@ spring:
       path: /h2-console #localhost:port/h2-console? ?? ??
 file:
   dir: /tmp
+ai:
+  model:
+    url: ${AI_MODEL_URL}

--- a/src/main/resources/templates/upload-img.html
+++ b/src/main/resources/templates/upload-img.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container">
+    <div class="py-5 text-center">
+        <h2>이미지 등록 폼</h2>
+    </div>
+    <h4 class="mb-3">이미지 추가</h4>
+    <form action="/upload" th:object="${ImgUploadRequest}" method="post" enctype="multipart/form-data">
+        <ul>높이 <input type="text" th:field="*{height}"></ul>
+        <ul>너비 <input type="text" th:field="*{width}"></ul>
+        <ul>파일 <input type="file" th:field="*{file}"></ul>
+        <input type="submit"/>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- 서버에서 외부 서버의 AI 모델에 이미지 조작을 요청할 수 있는 환경을 만든다
- 요청을 보내는 방식
  - html 폼(src/main/resources/templates/upload-img.html)에서 이미지 파일, 이미지 높이, 이미지 너비를 입력
  - submit 버튼을 클릭
  - 외부 서버의 AI 모델에 이미지 조작을 요청하는 post 요청 전달
- 외부 서버 응답 방식
  - 외부 서버는 code, resized_img, message 세 필드를 갖는 데이터로 응답
  - 성공 시에만 resized_img 필드에 값이 존재