### PR TITLE
DataBufferLimitException 문제를 해결한다

### DIFF
--- a/src/main/java/org/rogarithm/presize/config/WebClientConfig.java
+++ b/src/main/java/org/rogarithm/presize/config/WebClientConfig.java
@@ -9,6 +9,7 @@ public class WebClientConfig {
 
     @Bean
     public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
+        return WebClient
+                .builder();
     }
 }

--- a/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
@@ -2,29 +2,54 @@ package org.rogarithm.presize.service;
 
 import org.rogarithm.presize.service.dto.ImgUploadDto;
 import org.rogarithm.presize.web.response.ImgUploadResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 @Service
 public class ImgUploadService {
 
+    private static final Logger log = LoggerFactory.getLogger(ImgUploadService.class);
+
     @Value("${ai.model.url}")
     private String aiModelUrl;
+
+    @Value("${spring.codec.max-in-memory-size}")
+    private String maxInMemorySize;
 
     @Autowired
     private WebClient.Builder webClientBuilder;
 
     public ImgUploadResponse uploadImg(ImgUploadDto dto) {
-        WebClient webClient = webClientBuilder.build();
+        WebClient webClient = webClientBuilder
+                .exchangeStrategies(ExchangeStrategies
+                        .builder()
+                        .codecs(codecs -> codecs
+                                .defaultCodecs()
+                                .maxInMemorySize(20 * 1024 * 1024))
+                        .build()).
+                build();
         WebClient.ResponseSpec retrieve = webClient.post()
                 .uri(aiModelUrl)
                 .bodyValue(dto)
                 .retrieve();
         Mono<ImgUploadResponse> response = retrieve.bodyToMono(ImgUploadResponse.class);
-        ImgUploadResponse imgUploadResponse = response.block();
+        ImgUploadResponse imgUploadResponse = null;
+        try {
+            imgUploadResponse = response.block();
+        } catch (WebClientResponseException e) {
+            String errorMsg = e.getCause().getMessage();
+            String problematicSize = errorMsg.split(":")[1].replaceAll(" ", "");
+            log.error("Current response's buffer size({}) is higher than current max codec size({}).\n" +
+                            "To resolve, edit max codec size higher than {} both in WebClient configuration and application properties!",
+                    problematicSize, parseSizeToBytes(maxInMemorySize), problematicSize);
+        }
 
         if (imgUploadResponse == null) {
             throw new RuntimeException("Failed to retrieve a response from the AI model");
@@ -35,5 +60,14 @@ public class ImgUploadService {
         }
 
         throw new RuntimeException("Error from AI model: " + imgUploadResponse.getMessage());
+    }
+
+    private String parseSizeToBytes(String size) {
+        if (size.endsWith("KB")) {
+            return Integer.toString(Integer.parseInt(size.replace("KB", "").trim()) * 1024);
+        } else if (size.endsWith("MB")) {
+            return Integer.toString(Integer.parseInt(size.replace("MB", "").trim()) * 1024 * 1024);
+        }
+        return size;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
     console:
       enabled: true
       path: /h2-console #localhost:port/h2-console? ?? ??
+  codec:
+    max-in-memory-size: 20MB
 file:
   dir: /tmp
 ai:

--- a/src/test/java/org/rogarithm/presize/service/ImgUploadServiceTest.java
+++ b/src/test/java/org/rogarithm/presize/service/ImgUploadServiceTest.java
@@ -1,0 +1,16 @@
+package org.rogarithm.presize.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImgUploadServiceTest {
+    @Test
+    public void t() {
+        String errorMsg = "Exceeded limit on max bytes to buffer : 2097152";
+        String problematicSize = errorMsg.split(":")[1].replaceAll(" ", "");
+        Assertions.assertThat(Integer.parseInt(problematicSize)).isEqualTo(2097152);
+    }
+
+}

--- a/src/test/java/org/rogarithm/presize/service/ImgUploadServiceTest.java
+++ b/src/test/java/org/rogarithm/presize/service/ImgUploadServiceTest.java
@@ -3,14 +3,11 @@ package org.rogarithm.presize.service;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class ImgUploadServiceTest {
     @Test
-    public void t() {
+    public void test_parsing_DataBufferLimitException_err_msg() {
         String errorMsg = "Exceeded limit on max bytes to buffer : 2097152";
         String problematicSize = errorMsg.split(":")[1].replaceAll(" ", "");
         Assertions.assertThat(Integer.parseInt(problematicSize)).isEqualTo(2097152);
     }
-
 }

--- a/src/test/java/org/rogarithm/presize/service/dto/ImgUploadDtoTest.java
+++ b/src/test/java/org/rogarithm/presize/service/dto/ImgUploadDtoTest.java
@@ -1,0 +1,35 @@
+package org.rogarithm.presize.service.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImgUploadDtoTest {
+
+    @Test
+    public void t() throws IOException, URISyntaxException {
+        URL res = getClass().getClassLoader().getResource("encode_result2");
+        String base64Image = new String(Files.readAllBytes(Paths.get(res.toURI())));
+
+        try {
+            byte[] imageBytes = Base64.getDecoder().decode(base64Image);
+            // Check JPEG magic bytes
+            if (imageBytes[0] == (byte) 0xFF && imageBytes[1] == (byte) 0xD8 && imageBytes[2] == (byte) 0xFF) {
+                System.out.println("Valid JPEG image.");
+            } else {
+                System.out.println("Invalid image.");
+            }
+        } catch (IllegalArgumentException e) {
+            System.out.println("Invalid Base64 string.");
+        }
+    }
+
+
+}


### PR DESCRIPTION
 - 외부 서버로부터 받은 응답의 buffer size가 webclient에 설정되어 있는 buffer size보다 작을 경우 생기는 문제다
 - 현재 문제가 되는 size보다 크게 webclient의 설정을 바꿨다
 - 다음에 문제가 생겼을 때 해당 문제 발생 여부를 알 수 있게 하고, 어떤 값으로 재설정해야 하는지 알 수 있게 로직 변경 및 로그를 추가했다