### PR TITLE
AI 모델에 이미지 정육면체 변환을 요청할 수 있다

### DIFF
--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
@@ -1,0 +1,26 @@
+package org.rogarithm.presize.service.dto;
+
+import org.rogarithm.presize.web.request.ImgUncropRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Base64;
+
+public class ImgUncropDto {
+    private String img;
+
+    public ImgUncropDto(MultipartFile file) {
+        try {
+            this.img = Base64.getEncoder().encodeToString(file.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to encode image", e);
+        }
+    }
+
+    public static ImgUncropDto from(ImgUncropRequest request) {
+        return new ImgUncropDto(request.getFile());
+    }
+
+    public String getImg() {
+        return img;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
@@ -2,6 +2,7 @@ package org.rogarithm.presize.web;
 
 import org.rogarithm.presize.service.ImgUploadService;
 import org.rogarithm.presize.service.dto.ImgUploadDto;
+import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.rogarithm.presize.web.request.ImgUploadRequest;
 import org.rogarithm.presize.web.response.ImgUploadResponse;
 import org.slf4j.Logger;
@@ -23,8 +24,9 @@ public class ImgUploadController {
     }
 
     @GetMapping("/upload")
-    public String newFile(Model model, ImgUploadRequest request) {
+    public String newFile(Model model, ImgUploadRequest request, ImgUncropRequest uncropRequest) {
         model.addAttribute("ImgUploadRequest", request);
+        model.addAttribute("ImgUncropRequest", uncropRequest);
         return "upload-img";
     }
 

--- a/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgUploadController.java
@@ -1,9 +1,11 @@
 package org.rogarithm.presize.web;
 
 import org.rogarithm.presize.service.ImgUploadService;
+import org.rogarithm.presize.service.dto.ImgUncropDto;
 import org.rogarithm.presize.service.dto.ImgUploadDto;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.rogarithm.presize.web.request.ImgUploadRequest;
+import org.rogarithm.presize.web.response.ImgUncropResponse;
 import org.rogarithm.presize.web.response.ImgUploadResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +38,12 @@ public class ImgUploadController {
         return "upscale-result";
     }
 
+    @GetMapping("/uncrop")
+    public String showUncropResult(@ModelAttribute("uncropImg") String uncropImg, Model model) {
+        model.addAttribute("uncropImg", uncropImg);
+        return "uncrop-result";
+    }
+
     @PostMapping("/upscale")
     public String uploadImg(@ModelAttribute("ImgUploadRequest") ImgUploadRequest request, RedirectAttributes redirectAttributes) {
         ImgUploadDto from = new ImgUploadDto(request.getFile(), "1240", "1240");
@@ -45,6 +53,21 @@ public class ImgUploadController {
             redirectAttributes.addFlashAttribute("originalImg", from.getImg());
             redirectAttributes.addFlashAttribute("resizedImg", response.getResizedImg());
             return "redirect:upscale";
+        } else {
+            redirectAttributes.addFlashAttribute("error", "Image processing failed: " + response.getMessage());
+            return "redirect:upload";
+        }
+    }
+
+    @PostMapping("/uncrop")
+    public String uncropImg(@ModelAttribute("ImgUncropRequest") ImgUncropRequest request, RedirectAttributes redirectAttributes) {
+        ImgUncropDto from = new ImgUncropDto(request.getFile());
+        ImgUncropResponse response = service.uncropImg(from);
+
+        if (response.isSuccess()) {
+            redirectAttributes.addFlashAttribute("originalImg", from.getImg());
+            redirectAttributes.addFlashAttribute("uncropImg", response.getUncropImg());
+            return "redirect:uncrop";
         } else {
             redirectAttributes.addFlashAttribute("error", "Image processing failed: " + response.getMessage());
             return "redirect:upload";

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
@@ -1,0 +1,22 @@
+package org.rogarithm.presize.web.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImgUncropRequest {
+    private MultipartFile file;
+
+    public ImgUncropRequest() {
+    }
+
+    public ImgUncropRequest(MultipartFile file) {
+        this.file = file;
+    }
+
+    public MultipartFile getFile() {
+        return file;
+    }
+
+    public void setFile(MultipartFile file) {
+        this.file = file;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/web/response/ImgUncropResponse.java
+++ b/src/main/java/org/rogarithm/presize/web/response/ImgUncropResponse.java
@@ -1,0 +1,48 @@
+package org.rogarithm.presize.web.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class ImgUncropResponse {
+    private final int code;
+    @JsonProperty("uncrop_img")
+    private final String uncropImg;
+    private final String message;
+
+    @JsonCreator
+    public ImgUncropResponse(
+            @JsonProperty("code") int code,
+            @JsonProperty("uncrop_img") String uncropImg,
+            @JsonProperty("message") String message) {
+        this.code = code;
+        this.uncropImg = uncropImg;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getUncropImg() {
+        return uncropImg;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isSuccess() {
+        return code == 200 && uncropImg != null;
+    }
+
+    public String getUncropImgAsString() {
+        if (uncropImg != null) {
+            byte[] decodedBytes = Base64.getDecoder().decode(uncropImg);
+            return new String(decodedBytes, StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,9 @@ spring:
     max-in-memory-size: 20MB
 ai:
   model:
-    url: ${AI_MODEL_URL}
+    url:
+      upscale: ${AI_MODEL_URL_UPSCALE}
+      uncrop: ${AI_MODEL_URL_UNCROP}
 logging:
   file:
     name: logs/app.log

--- a/src/main/resources/templates/uncrop-result.html
+++ b/src/main/resources/templates/uncrop-result.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <title>Image Result</title>
+</head>
+<body>
+<div class="container">
+    <div class="py-5 text-center">
+        <h2>변환된 이미지</h2>
+    </div>
+    <div class="image-container">
+        <div class="original-image">
+            <img th:src="'data:image;base64,' + ${originalImg}" alt="원본 이미지"/>
+        </div>
+        <div class="manipulated-image">
+            <img th:src="'data:image;base64,' + ${uncropImg}" alt="변환된 이미지"/>
+        </div>
+    </div>
+    <a href="/upload">다른 이미지 변환하기</a>
+</div>
+</body>
+</html>
+
+<style>
+    .image-container {
+        display: flex;
+        height: 100vh;
+    }
+
+    .original-image, .manipulated-image {
+        flex: 1; /* 각 클래스를 갖는 태그가 50%의 너비를 갖는다 */
+        display: flex;
+        justify-content: center; /* 수평으로 중앙 정렬 */
+        align-items: center; /* 수직으로 중앙 정렬 */
+        overflow: hidden;
+    }
+
+    .original-image img, .manipulated-image img {
+        max-width: 100%; /* 이미지 너비를 container 안에 맞춘다 */
+        max-height: 100%; /* 이미지 높이를 container 안에 맞춘다 */
+        object-fit: contain;
+    }
+</style>

--- a/src/main/resources/templates/upload-img.html
+++ b/src/main/resources/templates/upload-img.html
@@ -8,10 +8,16 @@
     <div class="py-5 text-center">
         <h2>이미지 등록 폼</h2>
     </div>
-    <h4 class="mb-3">이미지 추가</h4>
+    <h4 class="mb-3">업스케일할 이미지 추가</h4>
     <form action="/upscale" th:object="${ImgUploadRequest}" method="post" enctype="multipart/form-data">
         <ul>높이 <input type="text" th:field="*{height}"></ul>
         <ul>너비 <input type="text" th:field="*{width}"></ul>
+        <ul>파일 <input type="file" th:field="*{file}"></ul>
+        <input type="submit"/>
+    </form>
+
+    <h4 class="mb-3">정육면체로 만들 이미지 추가</h4>
+    <form action="/uncrop" th:object="${ImgUncropRequest}" method="post" enctype="multipart/form-data">
         <ul>파일 <input type="file" th:field="*{file}"></ul>
         <input type="submit"/>
     </form>


### PR DESCRIPTION

AI 모델에 이미지 정육면체 변환을 요청할 수 있다
 - 기존 레이아웃(upload-img.html)에서 서버에서 외부 서버의 AI 모델에 이미지 정육면체 변환을 요청할 수 있도록 수정한다
 - 요청을 보내는 방식
   - html 폼(src/main/resources/templates/upload-img.html)의 하단에서 이미지
     파일을 선택
   - submit 버튼을 클릭
   - 외부 서버의 AI 모델에 이미지 정육면체 변환을 요청하는 post 요청 전달
 - 외부 서버 응답 방식
   - 외부 서버는 code, uncrop_img, message 세 필드를 갖는 데이터로 응답
   - 성공 시에만 uncrop_img 필드에 값이 존재
 - AI 모델 url 환경변수값을 정리한다
   - ai.model.url -> {ai.model.url.upscale, ai.model.url.uncrop}