### PR TITLE
비동기 처리 오류를 고친다

### DIFF
--- a/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
@@ -48,21 +48,9 @@ public class ImgPolishController {
         }
 
         ImgUncropRequest request = new ImgUncropRequest(taskId, file, targetRatio);
-        uncropImgAsync(request);
+        polishService.uncropImgAsync(request);
 
         return new PollingResponse(200, "wait", uploadService.makeUncropUrl(request));
-    }
-
-    @Async
-    public CompletableFuture<Void> uncropImgAsync(ImgUncropRequest request) throws FileUploadException {
-        String upscaledImg = processUncrop(request);
-        return uploadService.uploadUncropToS3(request, upscaledImg);
-    }
-
-    private String processUncrop(ImgUncropRequest request) {
-        ImgUncropDto dto = ImgUncropDto.from(request);
-        ImgUncropResponse response = polishService.uncropImg(dto);
-        return response.getResizedImg();
     }
 
     @PostMapping("/health-check")
@@ -84,19 +72,8 @@ public class ImgPolishController {
         }
 
         ImgUpscaleRequest request = new ImgUpscaleRequest(taskId, file, upscaleRatio);
-        upscaleImgAsync(request);
+        polishService.upscaleImgAsync(request);
         return new PollingResponse(200, "wait", uploadService.makeUrl(request));
     }
 
-    @Async
-    public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) throws FileUploadException {
-        String upscaledImg = processUpscale(request);
-        return uploadService.uploadToS3(request, upscaledImg);
-    }
-
-    private String processUpscale(ImgUpscaleRequest request) {
-        ImgUpscaleDto dto = ImgUpscaleDto.from(request);
-        ImgUpscaleResponse response = polishService.upscaleImg(dto);
-        return response.getResizedImg();
-    }
 }


### PR DESCRIPTION
 - @Async 메서드가 자신을 호출하는 메서드와 같은 클래스에 있으면 동기 방식으로 처리된다
 - 스프링에서 @Async를 프록시 기반 AOP를 이용해서 구현하기 때문에, 다른 @Async 메서드와 이를 호출하는 메서드가 서로 다른 클래스에 있어야 한다
 - 따라서 두 로직이 서로 다른 클래스에 위치하도록 분리한다
 - https://stackoverflow.com/questions/73258139/why-async-is-not-working-if-i-keep-async-method-in-same-class