### PR TITLE
비동기로 인한 Multipartfile 데이터 유실 문제를 해결한다

### DIFF
--- a/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
+++ b/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package org.rogarithm.presize.config;
 
+import org.rogarithm.presize.exception.AiModelRequestFailException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +11,12 @@ public class ControllerAdvice {
     @ExceptionHandler(RuntimeException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(final RuntimeException exception) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(AiModelRequestFailException.class)
+    protected ResponseEntity<ErrorResponse> handleAiModelRequestFailException(final AiModelRequestFailException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
         return errorResponse.makeResponseEntity();
     }
 }

--- a/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
+++ b/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
@@ -1,0 +1,15 @@
+package org.rogarithm.presize.config;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final RuntimeException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+        return errorResponse.makeResponseEntity();
+    }
+}

--- a/src/main/java/org/rogarithm/presize/config/ErrorCode.java
+++ b/src/main/java/org/rogarithm/presize/config/ErrorCode.java
@@ -3,7 +3,8 @@ package org.rogarithm.presize.config;
 public enum ErrorCode {
 
     BAD_REQUEST        (400, "잘못된 요청"),
-    NOT_EXISTS         (404, "리소스가 존재하지 않음");
+    NOT_EXISTS         (404, "리소스가 존재하지 않음"),
+    SERVER_FAULT       (500, "서버 처리 시 오류 발생");
 
     private final Integer code;
     private final String reason;

--- a/src/main/java/org/rogarithm/presize/config/ErrorCode.java
+++ b/src/main/java/org/rogarithm/presize/config/ErrorCode.java
@@ -1,0 +1,23 @@
+package org.rogarithm.presize.config;
+
+public enum ErrorCode {
+
+    BAD_REQUEST        (400, "잘못된 요청"),
+    NOT_EXISTS         (404, "리소스가 존재하지 않음");
+
+    private final Integer code;
+    private final String reason;
+
+    ErrorCode(Integer code, String reason) {
+        this.code = code;
+        this.reason = reason;
+    }
+
+    public Integer getCode() {
+        return this.code;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/config/ErrorResponse.java
+++ b/src/main/java/org/rogarithm/presize/config/ErrorResponse.java
@@ -1,0 +1,48 @@
+package org.rogarithm.presize.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
+class ErrorResponse {
+    private static final Logger log = LoggerFactory.getLogger(ErrorResponse.class);
+
+    private final Integer code;
+    private final String reason;
+
+    ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.reason = errorCode.getReason();
+    }
+
+    public Integer getCode() {
+        return this.code;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
+    public HttpStatusCode convertHttpStatusCode() {
+        Integer code = this.getCode();
+        try {
+            return HttpStatusCode.valueOf(code);
+        } catch (IllegalArgumentException e) {
+            log.error(
+                    "Cannot convert code into HttpStatusCode: {}. ErrorCode.code should be between 100 <= code <= 999",
+                    this.getCode(),
+                    e
+            );
+            throw new IllegalArgumentException(
+                    "Cannot convert code into HttpStatusCode: {}. ErrorCode.code should be between 100 <= code <= 999",
+                    e
+            );
+        }
+    }
+
+    public ResponseEntity<ErrorResponse> makeResponseEntity() {
+        HttpStatusCode httpStatusCode = this.convertHttpStatusCode();
+        return ResponseEntity.status(httpStatusCode).body(this);
+    }
+}

--- a/src/main/java/org/rogarithm/presize/exception/AiModelRequestEncodingFailException.java
+++ b/src/main/java/org/rogarithm/presize/exception/AiModelRequestEncodingFailException.java
@@ -1,0 +1,17 @@
+package org.rogarithm.presize.exception;
+
+import org.rogarithm.presize.config.ErrorCode;
+
+public class AiModelRequestEncodingFailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AiModelRequestEncodingFailException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/exception/AiModelRequestFailException.java
+++ b/src/main/java/org/rogarithm/presize/exception/AiModelRequestFailException.java
@@ -1,0 +1,17 @@
+package org.rogarithm.presize.exception;
+
+import org.rogarithm.presize.config.ErrorCode;
+
+public class AiModelRequestFailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AiModelRequestFailException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/exception/AiModelRequestMakingFailException.java
+++ b/src/main/java/org/rogarithm/presize/exception/AiModelRequestMakingFailException.java
@@ -1,0 +1,17 @@
+package org.rogarithm.presize.exception;
+
+import org.rogarithm.presize.config.ErrorCode;
+
+public class AiModelRequestMakingFailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AiModelRequestMakingFailException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/exception/S3FileUploadFailException.java
+++ b/src/main/java/org/rogarithm/presize/exception/S3FileUploadFailException.java
@@ -1,0 +1,17 @@
+package org.rogarithm.presize.exception;
+
+import org.rogarithm.presize.config.ErrorCode;
+
+public class S3FileUploadFailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public S3FileUploadFailException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/exception/StoreTempFileFailException.java
+++ b/src/main/java/org/rogarithm/presize/exception/StoreTempFileFailException.java
@@ -1,0 +1,17 @@
+package org.rogarithm.presize.exception;
+
+import org.rogarithm.presize.config.ErrorCode;
+
+public class StoreTempFileFailException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public StoreTempFileFailException(ErrorCode errorCode) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/rogarithm/presize/service/ExternalApiRequester.java
+++ b/src/main/java/org/rogarithm/presize/service/ExternalApiRequester.java
@@ -1,5 +1,7 @@
 package org.rogarithm.presize.service;
 
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestFailException;
 import org.rogarithm.presize.service.dto.ImgSquareDto;
 import org.rogarithm.presize.service.dto.ImgUncropDto;
 import org.rogarithm.presize.service.dto.ImgUpscaleDto;
@@ -57,14 +59,14 @@ public class ExternalApiRequester {
         }
 
         if (healthCheckResponse == null) {
-            throw new RuntimeException("Failed to retrieve a health check response from the AI model");
+            throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Failed to retrieve a health check response from the AI model"
         }
 
         if (healthCheckResponse.isSuccess()) {
             return healthCheckResponse;
         }
 
-        throw new RuntimeException("Health check error from AI model: " + healthCheckResponse.getMessage());
+        throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Health check error from AI model: " + healthCheckResponse.getMessage()
     }
 
     @Transactional
@@ -95,14 +97,14 @@ public class ExternalApiRequester {
         }
 
         if (imgUpscaleResponse == null) {
-            throw new RuntimeException("Failed to retrieve a upscale response from the AI model");
+            throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Failed to retrieve a upscale response from the AI model"
         }
 
         if (imgUpscaleResponse.isSuccess()) {
             return imgUpscaleResponse;
         }
 
-        throw new RuntimeException("Upscale error from AI model: " + imgUpscaleResponse.getMessage());
+        throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Upscale error from AI model: " + imgUpscaleResponse.getMessage()
     }
 
     @Transactional
@@ -133,14 +135,14 @@ public class ExternalApiRequester {
         }
 
         if (imgUncropResponse == null) {
-            throw new RuntimeException("Failed to retrieve a uncrop response from the AI model");
+            throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Failed to retrieve a uncrop response from the AI model"
         }
 
         if (imgUncropResponse.isSuccess()) {
             return imgUncropResponse;
         }
 
-        throw new RuntimeException("Uncrop error from AI model: " + imgUncropResponse.getMessage());
+        throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Uncrop error from AI model: " + imgUncropResponse.getMessage()
     }
 
     @Transactional
@@ -171,14 +173,14 @@ public class ExternalApiRequester {
         }
 
         if (imgSquareResponse == null) {
-            throw new RuntimeException("Failed to retrieve a uncrop response from the AI model");
+            throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Failed to retrieve a uncrop response from the AI model"
         }
 
         if (imgSquareResponse.isSuccess()) {
             return imgSquareResponse;
         }
 
-        throw new RuntimeException("Uncrop error from AI model: " + imgSquareResponse.getMessage());
+        throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Uncrop error from AI model: " + imgSquareResponse.getMessage()
     }
 
     private String parseSizeToBytes(String size) {

--- a/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
@@ -45,7 +45,13 @@ public class ImgPolishService {
 
     @Async
     public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) throws FileUploadException {
-        String upscaledImg = processUpscale(request);
+        String upscaledImg = null;
+        try {
+            upscaledImg = processUpscale(request);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
         return uploadService.uploadUpscaleImgToS3(request, upscaledImg);
     }
 

--- a/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
@@ -44,14 +44,8 @@ public class ImgPolishService {
     }
 
     @Async
-    public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) throws FileUploadException {
-        String upscaledImg = null;
-        try {
-            upscaledImg = processUpscale(request);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-        }
-
+    public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) {
+        String upscaledImg = processUpscale(request);
         return uploadService.uploadUpscaleImgToS3(request, upscaledImg);
     }
 

--- a/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgUploadService.java
@@ -1,7 +1,8 @@
 package org.rogarithm.presize.service;
 
 import io.awspring.cloud.s3.S3Exception;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.S3FileUploadFailException;
 import org.rogarithm.presize.web.request.ImgSquareRequest;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
@@ -37,21 +38,21 @@ public class ImgUploadService {
 
     public CompletableFuture<Void> uploadUpscaleImgToS3(ImgUpscaleRequest request,
                                                         String polishedImg
-    ) throws FileUploadException {
+    ) {
         String fileName = makeFullFileName(request.getTaskId());
         return processUpload(fileName, polishedImg);
     }
 
     public CompletableFuture<Void> uploadUncropImgToS3(ImgUncropRequest request,
                                                        String polishedImg
-    ) throws FileUploadException {
+    ) {
         String fileName = makeFullFileName(request.getTaskId());
         return processUpload(fileName, polishedImg);
     }
 
     public CompletableFuture<Void> uploadSquareImgToS3(ImgSquareRequest request,
                                                        String polishedImg
-    ) throws FileUploadException {
+    ) {
         String fileName = makeFullFileName(request.getTaskId());
         return processUpload(fileName, polishedImg);
     }
@@ -61,7 +62,7 @@ public class ImgUploadService {
         return taskId + fileExtension;
     }
 
-    private CompletableFuture<Void> processUpload(String fileName, String polishedImg) throws FileUploadException {
+    private CompletableFuture<Void> processUpload(String fileName, String polishedImg) {
         String directoryName = "img/";
         byte[] decodedBytes = Base64.getDecoder().decode(polishedImg);
 
@@ -78,7 +79,8 @@ public class ImgUploadService {
 
             return new CompletableFuture<>();
         } catch (IOException | S3Exception e) {
-            throw new FileUploadException("Error occurred during file upload: " + e.getMessage());
+            log.error(e.getMessage());
+            throw new S3FileUploadFailException(ErrorCode.SERVER_FAULT); // "Error occurred during file upload: " + e.getMessage()
         }
     }
 

--- a/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
+++ b/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
@@ -1,5 +1,8 @@
 package org.rogarithm.presize.service;
 
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.StoreTempFileFailException;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -20,7 +23,7 @@ public class TempFileStoreManager {
 
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(fileBytes));
         if (image == null) {
-            throw new RuntimeException("Invalid image file");
+            throw new StoreTempFileFailException(ErrorCode.SERVER_FAULT); // "Invalid image file"
         }
         Path imgPath = dirPath.resolve(originalFilename);
         ImageIO.write(image, "png", imgPath.toFile());

--- a/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
+++ b/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
@@ -11,11 +11,15 @@ import java.util.Objects;
 public class TempFileStoreManager {
     public void store(byte[] fileBytes, String originalFilename) throws IOException {
 
+        if (Objects.equals(originalFilename.split("\\.")[1], "webp")) {
+            return;
+        }
+
         Path dirPath = Path.of("/tmp/imgs");
         Files.createDirectories(dirPath);
 
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(fileBytes));
-        if (!Objects.equals(originalFilename.split("\\.")[1], "webp") && image == null) {
+        if (image == null) {
             throw new RuntimeException("Invalid image file");
         }
         Path imgPath = dirPath.resolve(originalFilename);

--- a/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
+++ b/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
@@ -1,0 +1,24 @@
+package org.rogarithm.presize.service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class TempFileStoreManager {
+    public void store(byte[] fileBytes, String originalFilename) throws IOException {
+
+        Path dirPath = Path.of("/tmp/imgs");
+        Files.createDirectories(dirPath);
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(fileBytes));
+        if (!Objects.equals(originalFilename.split("\\.")[1], "webp") && image == null) {
+            throw new RuntimeException("Invalid image file");
+        }
+        Path imgPath = dirPath.resolve(originalFilename);
+        ImageIO.write(image, "png", imgPath.toFile());
+    }
+}

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgSquareDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgSquareDto.java
@@ -1,6 +1,8 @@
 package org.rogarithm.presize.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
 import org.rogarithm.presize.web.request.ImgSquareRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,7 +20,7 @@ public class ImgSquareDto {
         try {
             this.img = Base64.getEncoder().encodeToString(file.getBytes());
         } catch (Exception e) {
-            throw new RuntimeException("Failed to encode image", e);
+            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT); // "Failed to encode image", e
         }
         this.targetRes = targetRes;
     }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
@@ -1,6 +1,8 @@
 package org.rogarithm.presize.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,7 +17,7 @@ public class ImgUncropDto {
         try {
             this.img = Base64.getEncoder().encodeToString(file.getBytes());
         } catch (Exception e) {
-            throw new RuntimeException("Failed to encode image", e);
+            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT); // "Failed to encode image", e
         }
         this.targetRatio = targetRatio;
     }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
@@ -3,11 +3,15 @@ package org.rogarithm.presize.service.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.rogarithm.presize.service.TempFileStoreManager;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Base64;
 
 public class ImgUpscaleDto {
+    private static final Logger log = LoggerFactory.getLogger(ImgUpscaleDto.class);
+
     private String img;
     @JsonProperty("upscale_ratio")
     private String upscaleRatio;
@@ -25,6 +29,7 @@ public class ImgUpscaleDto {
             // Base64 인코딩
             this.img = encodeWithPadding(Base64.getEncoder().encodeToString(fileBytes));
         } catch (Exception e) {
+            log.error(e.getMessage(), e);
             throw new RuntimeException("ImgUpscaleDto: Failed to encode image", e);
         }
         this.upscaleRatio = upscaleRatio;

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
@@ -7,7 +7,6 @@ import org.rogarithm.presize.service.TempFileStoreManager;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Base64;
 
@@ -19,14 +18,12 @@ public class ImgUpscaleDto {
     private String upscaleRatio;
 
     public ImgUpscaleDto(
-            MultipartFile file,
+            byte[] fileBytes,
             @JsonProperty("upscale_ratio") String upscaleRatio
     ) {
         try {
-            byte[] fileBytes = file.getBytes();
-
             TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
-            tempFileStoreManager.store(fileBytes, file.getOriginalFilename());
+            tempFileStoreManager.store(fileBytes, "temp"); //file.getOriginalFilename());
 
             // Base64 인코딩
             this.img = encodeWithPadding(Base64.getEncoder().encodeToString(fileBytes));
@@ -38,7 +35,7 @@ public class ImgUpscaleDto {
     }
 
     public static ImgUpscaleDto from(ImgUpscaleRequest request) {
-        return new ImgUpscaleDto(request.getFile(), request.getUpscaleRatio());
+        return new ImgUpscaleDto(request.getFileBytes(), request.getUpscaleRatio());
     }
 
     public String getImg() {

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
@@ -1,6 +1,7 @@
 package org.rogarithm.presize.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.rogarithm.presize.service.TempFileStoreManager;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,9 +17,15 @@ public class ImgUpscaleDto {
             @JsonProperty("upscale_ratio") String upscaleRatio
     ) {
         try {
-            this.img = encodeWithPadding(Base64.getEncoder().encodeToString(file.getBytes()));
+            byte[] fileBytes = file.getBytes();
+
+            TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
+            tempFileStoreManager.store(fileBytes, file.getOriginalFilename());
+
+            // Base64 인코딩
+            this.img = encodeWithPadding(Base64.getEncoder().encodeToString(fileBytes));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to encode image", e);
+            throw new RuntimeException("ImgUpscaleDto: Failed to encode image", e);
         }
         this.upscaleRatio = upscaleRatio;
     }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
@@ -2,8 +2,7 @@ package org.rogarithm.presize.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.rogarithm.presize.config.ErrorCode;
-import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
-import org.rogarithm.presize.service.TempFileStoreManager;
+import org.rogarithm.presize.exception.AiModelRequestEncodingFailException;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,14 +21,11 @@ public class ImgUpscaleDto {
             @JsonProperty("upscale_ratio") String upscaleRatio
     ) {
         try {
-            TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
-            tempFileStoreManager.store(fileBytes, "temp"); //file.getOriginalFilename());
-
             // Base64 인코딩
             this.img = encodeWithPadding(Base64.getEncoder().encodeToString(fileBytes));
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT); // "ImgUpscaleDto: Failed to encode image", e
+            throw new AiModelRequestEncodingFailException(ErrorCode.SERVER_FAULT); // "ImgUpscaleDto: Failed to encode image", e
         }
         this.upscaleRatio = upscaleRatio;
     }

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUpscaleDto.java
@@ -1,6 +1,8 @@
 package org.rogarithm.presize.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
 import org.rogarithm.presize.service.TempFileStoreManager;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
 import org.slf4j.Logger;
@@ -30,7 +32,7 @@ public class ImgUpscaleDto {
             this.img = encodeWithPadding(Base64.getEncoder().encodeToString(fileBytes));
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException("ImgUpscaleDto: Failed to encode image", e);
+            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT); // "ImgUpscaleDto: Failed to encode image", e
         }
         this.upscaleRatio = upscaleRatio;
     }

--- a/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
@@ -71,7 +71,7 @@ public class ImgPolishController {
             @RequestParam("file") MultipartFile file,
             @RequestParam("upscaleRatio") String upscaleRatio,
             HttpServletRequest httpServletRequest
-    ) throws FileUploadException {
+    ) {
         logRequest(httpServletRequest);
 
         HealthCheckResponse healthCheckResponse = polishService.healthCheck();

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
@@ -2,17 +2,24 @@ package org.rogarithm.presize.web.request;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 public class ImgUpscaleRequest {
     private String taskId;
-    private MultipartFile file;
+    private byte[] fileBytes;
     private String upscaleRatio;
 
     public ImgUpscaleRequest() {
     }
 
     public ImgUpscaleRequest(String taskId, MultipartFile file, String upscaleRatio) {
+        try {
+            byte[] fileBytes = file.getBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
         this.taskId = taskId;
-        this.file = file;
         this.upscaleRatio = upscaleRatio;
     }
 
@@ -20,8 +27,8 @@ public class ImgUpscaleRequest {
         return taskId;
     }
 
-    public MultipartFile getFile() {
-        return file;
+    public byte[] getFileBytes() {
+        return fileBytes;
     }
 
     public String getUpscaleRatio() {
@@ -32,8 +39,8 @@ public class ImgUpscaleRequest {
         this.taskId = taskId;
     }
 
-    public void setFile(MultipartFile file) {
-        this.file = file;
+    public void setFileBytes(byte[] fileBytes) {
+        this.fileBytes = fileBytes;
     }
 
     public void setUpscaleRatio(String upscaleRatio) {

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
@@ -2,7 +2,6 @@ package org.rogarithm.presize.web.request;
 
 import org.rogarithm.presize.config.ErrorCode;
 import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
-import org.rogarithm.presize.service.TempFileStoreManager;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ImgUpscaleRequest {
@@ -17,9 +16,6 @@ public class ImgUpscaleRequest {
         try {
             byte[] fileBytes = file.getBytes();
             this.fileBytes = fileBytes;
-
-            TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
-            tempFileStoreManager.store(fileBytes, file.getOriginalFilename());
         } catch (Exception e) {
             throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT);
         }

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
@@ -16,6 +16,7 @@ public class ImgUpscaleRequest {
     public ImgUpscaleRequest(String taskId, MultipartFile file, String upscaleRatio) {
         try {
             byte[] fileBytes = file.getBytes();
+            this.fileBytes = fileBytes;
 
             TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
             tempFileStoreManager.store(fileBytes, file.getOriginalFilename());

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
@@ -1,8 +1,9 @@
 package org.rogarithm.presize.web.request;
 
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
+import org.rogarithm.presize.service.TempFileStoreManager;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 public class ImgUpscaleRequest {
     private String taskId;
@@ -15,8 +16,11 @@ public class ImgUpscaleRequest {
     public ImgUpscaleRequest(String taskId, MultipartFile file, String upscaleRatio) {
         try {
             byte[] fileBytes = file.getBytes();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+
+            TempFileStoreManager tempFileStoreManager = new TempFileStoreManager();
+            tempFileStoreManager.store(fileBytes, file.getOriginalFilename());
+        } catch (Exception e) {
+            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT);
         }
 
         this.taskId = taskId;


### PR DESCRIPTION
예외 처리 로직 구현
 - 예외를 상위 레이어로 올리는 대신, 예외가 발생한 레이어에서 처리하도록 변경
 - 예외 처리를 ControllerAdvice 기반으로 변경

비동기로 인한 Multipartfile 데이터 유실 문제 처리
 - MultipartFile 타입 값을 받은 첫 메서드에서 file 필드 값을 미리 저장해서,
 이후 메서드에서 MultipartFile.file 값을 쓸 수 있도록 변경