### PR TITLE
upscale 요청이 많아졌을 때 서버가 응답하지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
+++ b/src/main/java/org/rogarithm/presize/config/ControllerAdvice.java
@@ -1,6 +1,6 @@
 package org.rogarithm.presize.config;
 
-import org.rogarithm.presize.exception.AiModelRequestFailException;
+import org.rogarithm.presize.exception.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -16,6 +16,30 @@ public class ControllerAdvice {
 
     @ExceptionHandler(AiModelRequestFailException.class)
     protected ResponseEntity<ErrorResponse> handleAiModelRequestFailException(final AiModelRequestFailException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(AiModelRequestEncodingFailException.class)
+    protected ResponseEntity<ErrorResponse> handleAiModelRequestEncodingFailException(final AiModelRequestEncodingFailException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(AiModelRequestMakingFailException.class)
+    protected ResponseEntity<ErrorResponse> handleAiModelRequestMakingFailException(final AiModelRequestMakingFailException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(S3FileUploadFailException.class)
+    protected ResponseEntity<ErrorResponse> handleS3FileUploadFailException(final S3FileUploadFailException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
+        return errorResponse.makeResponseEntity();
+    }
+
+    @ExceptionHandler(StoreTempFileFailException.class)
+    protected ResponseEntity<ErrorResponse> handleStoreTempFileFailException(final StoreTempFileFailException exception) {
         ErrorResponse errorResponse = new ErrorResponse(exception.getErrorCode());
         return errorResponse.makeResponseEntity();
     }

--- a/src/main/java/org/rogarithm/presize/service/ExternalApiRequester.java
+++ b/src/main/java/org/rogarithm/presize/service/ExternalApiRequester.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -39,7 +38,6 @@ public class ExternalApiRequester {
     @Autowired
     private WebClient webClient;
 
-    @Transactional
     public HealthCheckResponse healthCheck() {
         WebClient.ResponseSpec retrieve = webClient.post()
                 .uri(healthCheckUrl)
@@ -69,7 +67,6 @@ public class ExternalApiRequester {
         throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Health check error from AI model: " + healthCheckResponse.getMessage()
     }
 
-    @Transactional
     public ImgUpscaleResponse upscaleImg(ImgUpscaleDto dto) {
         WebClient.ResponseSpec retrieve = webClient.post()
                 .uri(upscaleUrl)
@@ -107,7 +104,6 @@ public class ExternalApiRequester {
         throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Upscale error from AI model: " + imgUpscaleResponse.getMessage()
     }
 
-    @Transactional
     public ImgUncropResponse uncropImg(ImgUncropDto dto) {
         WebClient.ResponseSpec retrieve = webClient.post()
                 .uri(uncropUrl)
@@ -145,7 +141,6 @@ public class ExternalApiRequester {
         throw new AiModelRequestFailException(ErrorCode.SERVER_FAULT); // "Uncrop error from AI model: " + imgUncropResponse.getMessage()
     }
 
-    @Transactional
     public ImgSquareResponse squareImg(ImgSquareDto dto) {
         WebClient.ResponseSpec retrieve = webClient.post()
                 .uri(squareUrl)

--- a/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
@@ -46,7 +46,7 @@ public class ImgPolishService {
     @Async
     public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) {
         String upscaledImg = processUpscale(request);
-        return uploadService.uploadUpscaleImgToS3(request, upscaledImg);
+        return null; //uploadService.uploadUpscaleImgToS3(request, upscaledImg);
     }
 
     private String processUpscale(ImgUpscaleRequest request) {

--- a/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
+++ b/src/main/java/org/rogarithm/presize/service/TempFileStoreManager.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Objects;
 
 public class TempFileStoreManager {
@@ -21,7 +22,9 @@ public class TempFileStoreManager {
         Path dirPath = Path.of("/tmp/imgs");
         Files.createDirectories(dirPath);
 
-        BufferedImage image = ImageIO.read(new ByteArrayInputStream(fileBytes));
+        byte[] decodedFileBytes = Base64.getDecoder().decode(fileBytes);
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(decodedFileBytes));
         if (image == null) {
             throw new StoreTempFileFailException(ErrorCode.SERVER_FAULT); // "Invalid image file"
         }

--- a/src/main/java/org/rogarithm/presize/web/ImgPolishPageController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgPolishPageController.java
@@ -3,16 +3,17 @@ package org.rogarithm.presize.web;
 import org.rogarithm.presize.service.ExternalApiRequester;
 import org.rogarithm.presize.service.ImgPolishService;
 import org.rogarithm.presize.service.dto.ImgUncropDto;
-import org.rogarithm.presize.service.dto.ImgUpscaleDto;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
 import org.rogarithm.presize.web.response.ImgUncropResponse;
-import org.rogarithm.presize.web.response.ImgUpscaleResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -50,23 +51,6 @@ public class ImgPolishPageController {
     public String showUncropResult(@ModelAttribute("uncropImg") String uncropImg, Model model) {
         model.addAttribute("uncropImg", uncropImg);
         return "uncrop-result";
-    }
-
-    @PostMapping("/upscale")
-    public String uploadImg(@ModelAttribute("ImgUpscaleRequest") ImgUpscaleRequest request, RedirectAttributes redirectAttributes) {
-        request.setTaskId("x");
-        request.setUpscaleRatio("x2");
-        ImgUpscaleDto dto = ImgUpscaleDto.from(request);
-        ImgUpscaleResponse response = externalApiRequester.upscaleImg(dto);
-
-        if (response.isSuccess()) {
-            redirectAttributes.addFlashAttribute("originalImg", dto.getImg());
-            redirectAttributes.addFlashAttribute("resizedImg", response.getResizedImg());
-            return "redirect:upscale";
-        } else {
-            redirectAttributes.addFlashAttribute("error", "Image processing failed: " + response.getMessage());
-            return "redirect:upload";
-        }
     }
 
     @PostMapping("/uncrop")

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUpscaleRequest.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImgUpscaleRequest {
     private String taskId;
     private byte[] fileBytes;
+    private String originalFileName;
     private String upscaleRatio;
 
     public ImgUpscaleRequest() {
@@ -21,6 +22,7 @@ public class ImgUpscaleRequest {
         }
 
         this.taskId = taskId;
+        this.originalFileName = file.getOriginalFilename();
         this.upscaleRatio = upscaleRatio;
     }
 
@@ -30,6 +32,10 @@ public class ImgUpscaleRequest {
 
     public byte[] getFileBytes() {
         return fileBytes;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
     }
 
     public String getUpscaleRatio() {
@@ -42,6 +48,10 @@ public class ImgUpscaleRequest {
 
     public void setFileBytes(byte[] fileBytes) {
         this.fileBytes = fileBytes;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
     }
 
     public void setUpscaleRatio(String upscaleRatio) {


### PR DESCRIPTION
- WebClient를 동기 방식으로 써서 요청이 많아졌을 때 모든 쓰레드가
   새로운 요청을 받아 처리할 상태가 되지 않는 문제가 발생하고 있었다
- WebClient 호출 방식을 비동기 방식으로 변경하고, 호출 이후 연산이
   WebClient 호출로부터 응답을 모두 받고 나서 이뤄지도록 구현한다
- 변경 후 AI 모델에 보낸 요청에 대한 응답이 모두 정상적으로
   돌아오는지를 TempFileStoreManager.store()를 통해 확인한다. 이
   메서드를 호출하는 시점이 기존과 달라져서 깨지는 부분을 고친다
  - 요청으로 보낸 파일의 이름으로 임시 파일을 저장할 수 있도록
    ImgUpscaleRequest에 originalFileName 필드를 추가한다
  - AI 모델로부터 받은 파일 내용은 base64 인코딩된 형식인데, 그러면
    파일을 제대로 저장할 수 없다. 디코딩해서 저장하도록 바꾼다
- 테스트용 컨트롤러를 제거한다.