### PR TITLE
uncrop 요청이 많아졌을 때 서버가 응답하지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
+++ b/src/main/java/org/rogarithm/presize/service/ImgPolishService.java
@@ -1,8 +1,6 @@
 package org.rogarithm.presize.service;
 
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
-import org.rogarithm.presize.config.ErrorCode;
-import org.rogarithm.presize.exception.StoreTempFileFailException;
 import org.rogarithm.presize.service.dto.ImgSquareDto;
 import org.rogarithm.presize.service.dto.ImgUncropDto;
 import org.rogarithm.presize.service.dto.ImgUpscaleDto;
@@ -18,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -37,13 +34,6 @@ public class ImgPolishService {
     @Async
     public CompletableFuture<Void> uncropImgAsync(ImgUncropRequest request) {
         CompletableFuture<Void> voidCompletableFuture = processUncrop(request).thenAcceptAsync(result -> {
-            byte[] bytes = result.getResizedImg().getBytes();
-            TempFileStoreManager tfsm = new TempFileStoreManager();
-            try {
-                tfsm.store(bytes, request.getOriginalFileName());
-            } catch (IOException e) {
-                throw new StoreTempFileFailException(ErrorCode.SERVER_FAULT);
-            }
             uploadService.uploadUncropImgToS3(request, result.getResizedImg());
         });
         return voidCompletableFuture;
@@ -58,13 +48,6 @@ public class ImgPolishService {
     @Async
     public CompletableFuture<Void> upscaleImgAsync(ImgUpscaleRequest request) {
         CompletableFuture<Void> voidCompletableFuture = processUpscale(request).thenAccept(result -> {
-            byte[] bytes = result.getResizedImg().getBytes();
-            TempFileStoreManager tfsm = new TempFileStoreManager();
-            try {
-                tfsm.store(bytes, request.getOriginalFileName());
-            } catch (IOException e) {
-                throw new StoreTempFileFailException(ErrorCode.SERVER_FAULT);
-            }
             uploadService.uploadUpscaleImgToS3(request, result.getResizedImg());
         });
         return voidCompletableFuture;

--- a/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
+++ b/src/main/java/org/rogarithm/presize/service/dto/ImgUncropDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.rogarithm.presize.config.ErrorCode;
 import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Base64;
 
@@ -13,9 +12,9 @@ public class ImgUncropDto {
     @JsonProperty("target_ratio")
     private String targetRatio;
 
-    public ImgUncropDto(MultipartFile file, String targetRatio) {
+    public ImgUncropDto(byte[] fileBytes, String targetRatio) {
         try {
-            this.img = Base64.getEncoder().encodeToString(file.getBytes());
+            this.img = Base64.getEncoder().encodeToString(fileBytes);
         } catch (Exception e) {
             throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT); // "Failed to encode image", e
         }
@@ -23,7 +22,7 @@ public class ImgUncropDto {
     }
 
     public static ImgUncropDto from(ImgUncropRequest request) {
-        return new ImgUncropDto(request.getFile(), request.getTargetRatio());
+        return new ImgUncropDto(request.getFileBytes(), request.getTargetRatio());
     }
 
     public String getImg() {

--- a/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgPolishController.java
@@ -45,7 +45,7 @@ public class ImgPolishController {
             @RequestParam("file") MultipartFile file,
             @RequestParam("targetRatio") String targetRatio,
             HttpServletRequest httpServletRequest
-    ) throws FileUploadException {
+    ) {
         logRequest(httpServletRequest);
 
         HealthCheckResponse healthCheckResponse = polishService.healthCheck();

--- a/src/main/java/org/rogarithm/presize/web/ImgPolishPageController.java
+++ b/src/main/java/org/rogarithm/presize/web/ImgPolishPageController.java
@@ -2,19 +2,15 @@ package org.rogarithm.presize.web;
 
 import org.rogarithm.presize.service.ExternalApiRequester;
 import org.rogarithm.presize.service.ImgPolishService;
-import org.rogarithm.presize.service.dto.ImgUncropDto;
 import org.rogarithm.presize.web.request.ImgUncropRequest;
 import org.rogarithm.presize.web.request.ImgUpscaleRequest;
-import org.rogarithm.presize.web.response.ImgUncropResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/test")
@@ -51,22 +47,5 @@ public class ImgPolishPageController {
     public String showUncropResult(@ModelAttribute("uncropImg") String uncropImg, Model model) {
         model.addAttribute("uncropImg", uncropImg);
         return "uncrop-result";
-    }
-
-    @PostMapping("/uncrop")
-    public String uncropImg(@ModelAttribute("ImgUncropRequest") ImgUncropRequest request, RedirectAttributes redirectAttributes) {
-        request.setTaskId("y");
-        request.setTargetRatio("1:2");
-        ImgUncropDto dto = ImgUncropDto.from(request);
-        ImgUncropResponse response = externalApiRequester.uncropImg(dto);
-
-        if (response.isSuccess()) {
-            redirectAttributes.addFlashAttribute("originalImg", dto.getImg());
-            redirectAttributes.addFlashAttribute("uncropImg", response.getResizedImg());
-            return "redirect:uncrop";
-        } else {
-            redirectAttributes.addFlashAttribute("error", "Image processing failed: " + response.getMessage());
-            return "redirect:upload";
-        }
     }
 }

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImgUncropRequest {
     private String taskId;
     private byte[] fileBytes;
+    private String originalFileName;
     private String targetRatio;
 
     public ImgUncropRequest() {
@@ -21,6 +22,7 @@ public class ImgUncropRequest {
         }
 
         this.taskId = taskId;
+        this.originalFileName = file.getOriginalFilename();
         this.targetRatio = targetRatio;
     }
 
@@ -30,6 +32,10 @@ public class ImgUncropRequest {
 
     public byte[] getFileBytes() {
         return fileBytes;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
     }
 
     public String getTargetRatio() {
@@ -42,6 +48,10 @@ public class ImgUncropRequest {
 
     public void setFileBytes(byte[] fileBytes) {
         this.fileBytes = fileBytes;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
     }
 
     public void setTargetRatio(String targetRatio) {

--- a/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
+++ b/src/main/java/org/rogarithm/presize/web/request/ImgUncropRequest.java
@@ -1,18 +1,26 @@
 package org.rogarithm.presize.web.request;
 
+import org.rogarithm.presize.config.ErrorCode;
+import org.rogarithm.presize.exception.AiModelRequestMakingFailException;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ImgUncropRequest {
     private String taskId;
-    private MultipartFile file;
+    private byte[] fileBytes;
     private String targetRatio;
 
     public ImgUncropRequest() {
     }
 
     public ImgUncropRequest(String taskId, MultipartFile file, String targetRatio) {
+        try {
+            byte[] fileBytes = file.getBytes();
+            this.fileBytes = fileBytes;
+        } catch (Exception e) {
+            throw new AiModelRequestMakingFailException(ErrorCode.SERVER_FAULT);
+        }
+
         this.taskId = taskId;
-        this.file = file;
         this.targetRatio = targetRatio;
     }
 
@@ -20,8 +28,8 @@ public class ImgUncropRequest {
         return taskId;
     }
 
-    public MultipartFile getFile() {
-        return file;
+    public byte[] getFileBytes() {
+        return fileBytes;
     }
 
     public String getTargetRatio() {
@@ -32,8 +40,8 @@ public class ImgUncropRequest {
         this.taskId = taskId;
     }
 
-    public void setFile(MultipartFile file) {
-        this.file = file;
+    public void setFileBytes(byte[] fileBytes) {
+        this.fileBytes = fileBytes;
     }
 
     public void setTargetRatio(String targetRatio) {


### PR DESCRIPTION
- https://github.com/rogarithm/freesize/pull/20 과 동일한 처리 과정을 적용한다
- uncrop 처리에 소요되는 시간이 upscale에 비해 많아서, thenAccept() 적용했을 때
AI 모델에서 응답이 오기 전에 이후 연산이 실행되는 경우가 생겼다. 이를 thenAcceptAsync()로 해결한다